### PR TITLE
fix nil pointer deref in datasource reconcile

### DIFF
--- a/pkg/controller/grafanadatasource/datasource_controller.go
+++ b/pkg/controller/grafanadatasource/datasource_controller.go
@@ -139,6 +139,10 @@ type ReconcileGrafanaDataSource struct {
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileGrafanaDataSource) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	client, err := r.getClient()
+	if err != nil {
+		log.V(1).Info("%v", err)
+		return reconcile.Result{RequeueAfter: config.RequeueDelay}, nil
+	}
 	// Read the current state of known and cluster datasources
 	currentState := common.NewDataSourcesState()
 	err = currentState.Read(r.context, r.client, request.Namespace)


### PR DESCRIPTION
## Description
During datasource reconcile, the `err` from `getClient()` was never checked. I'm not sure what can break `getClient()`, but in the linked ticket you can see a stacktrace where it apparently hit the case of a `nil` client. This should log the error rather than attempt to dereference a nil pointer.

## Relevant issues/tickets
https://infoblox.atlassian.net/browse/CMR-873

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
