### PR TITLE
only push image after PR merge

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,13 +30,19 @@ pipeline {
   }
   post {
     success {
-      dir("${PROJECT}") {
-        finalizeBuild(
-          sh(
-            script: 'make image/show',
-            returnStdout: true
-          )
-        )
+      script {
+        if (env.BRANCH_NAME == 'master') {
+          dir("${PROJECT}") {
+            finalizeBuild(
+              sh(
+                script: 'make image/show',
+                returnStdout: true
+              )
+            )
+          }
+        } else {
+          echo "not pushing image built on ${env.BRANCH_NAME}"
+        }
       }
     }
     cleanup {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes, Please add any additional motivation and context as needed -->
Fixes issue where Dependabot picks up PR build of image and recommends an upgrade to it.
## Relevant issues/tickets
<!-- Please include a link to the issue or ticket that applies to this pull request, delete this heading if not relevant -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
