### PR TITLE
Use underscores in grafana_plugins_init image name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ generate: controller-gen
 docker-build: test
 	DOCKER_BUILDKIT=1 docker build -t ${IMG} .
 	#TODO: Remove once upstream auto-builds with updated images
-	DOCKER_BUILDKIT=1 docker build -t ${ORG}/grafana-plugins-init:${TAG} ./grafana_plugins_init
+	DOCKER_BUILDKIT=1 docker build -t ${ORG}/grafana_plugins_init:${TAG} ./grafana_plugins_init
 
 # Push the single-architecture docker image
 docker-push:
@@ -225,4 +225,4 @@ catalog-push: ## Push the catalog image.
 
 .PHONY: image/show
 image/show:
-	@echo ${IMG} ${ORG}/grafana-plugins-init:${TAG}
+	@echo ${IMG} ${ORG}/grafana_plugins_init:${TAG}


### PR DESCRIPTION
## Description

The original plugins_init container uses underscores, so this really should, too

## Relevant issues/tickets
<!-- Please include a link to the issue or ticket that applies to this pull request, delete this heading if not relevant -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] This change requires a documentation update 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
